### PR TITLE
fix: limit options chars to slack set 75 chars

### DIFF
--- a/frappe_slack_connector/api/slash_timesheet.py
+++ b/frappe_slack_connector/api/slash_timesheet.py
@@ -4,6 +4,7 @@ from frappe_slack_connector.db.timesheet import get_user_projects, get_user_task
 from frappe_slack_connector.db.user_meta import get_userid_from_slackid
 from frappe_slack_connector.helpers.error import generate_error_log
 from frappe_slack_connector.helpers.http_response import send_http_response
+from frappe_slack_connector.helpers.str_utils import truncate_text
 from frappe_slack_connector.slack.app import SlackIntegration
 
 
@@ -124,7 +125,8 @@ def build_timesheet_form(projects: list, tasks: list) -> list:
                     {
                         "text": {
                             "type": "plain_text",
-                            "text": project.get("project_name"),
+                            # Limit the text to 75 characters
+                            "text": truncate_text(project.get("project_name")),
                         },
                         "value": project.get("name"),
                     }
@@ -145,7 +147,10 @@ def build_timesheet_form(projects: list, tasks: list) -> list:
                     {
                         "text": {
                             "type": "plain_text",
-                            "text": task.get("subject"),
+                            # Limit the text to 75 characters
+                            "text": truncate_text(
+                                task.get("subject", task.get("name", ""))
+                            ),
                         },
                         "value": task.get("name"),
                     }

--- a/frappe_slack_connector/helpers/str_utils.py
+++ b/frappe_slack_connector/helpers/str_utils.py
@@ -1,5 +1,7 @@
 import re
 
+from frappe_slack_connector.slack.app import SlackIntegration
+
 
 def strip_html_tags(text):
     """
@@ -12,3 +14,10 @@ def strip_html_tags(text):
     clean_text = re.sub(pattern, "", text)
 
     return clean_text
+
+
+def truncate_text(text, limit=SlackIntegration.SLACK_CHAR_LIMIT):
+    """
+    Truncate the text to the given limit
+    """
+    return text[:limit]

--- a/frappe_slack_connector/slack/app.py
+++ b/frappe_slack_connector/slack/app.py
@@ -15,6 +15,8 @@ from frappe_slack_connector.helpers.error import generate_error_log
 
 
 class SlackIntegration:
+    SLACK_CHAR_LIMIT = 75
+
     def __init__(self):
         """
         Initialize the Slack Integration instance

--- a/frappe_slack_connector/slack/interactions/timesheet_filters.py
+++ b/frappe_slack_connector/slack/interactions/timesheet_filters.py
@@ -3,7 +3,7 @@ import frappe
 from frappe_slack_connector.db.timesheet import get_user_tasks
 from frappe_slack_connector.db.user_meta import get_userid_from_slackid
 from frappe_slack_connector.helpers.error import generate_error_log
-from frappe_slack_connector.helpers.str_utils import strip_html_tags
+from frappe_slack_connector.helpers.str_utils import strip_html_tags, truncate_text
 from frappe_slack_connector.slack.app import SlackIntegration
 
 
@@ -107,7 +107,8 @@ def handle_project_select(slack: SlackIntegration, payload: dict):
                 {
                     "text": {
                         "type": "plain_text",
-                        "text": task.get("subject"),
+                        # Limit the task subject to 75 characters
+                        "text": truncate_text(task.get("subject")),
                     },
                     "value": task.get("name"),
                 }
@@ -154,7 +155,7 @@ def handle_task_select(slack: SlackIntegration, payload: dict):
             block["element"]["initial_option"] = {
                 "text": {
                     "type": "plain_text",
-                    "text": project_name,
+                    "text": truncate_text(project_name),
                 },
                 "value": project_id,
             }


### PR DESCRIPTION
- https://github.com/rtCamp/frappe-slack-connector/issues/54
Slack doesn't allow options to be more than 75 characters, so the API is throwing an error.
This PR introduces a truncate function that limits the user inputs (from ERP) to Slack permissible 75 chars.

