### PR TITLE
fix: show task name as description, raise limit to 99, check if project not found while selecting task

### DIFF
--- a/frappe_slack_connector/api/slash_timesheet.py
+++ b/frappe_slack_connector/api/slash_timesheet.py
@@ -153,6 +153,10 @@ def build_timesheet_form(projects: list, tasks: list) -> list:
                             ),
                         },
                         "value": task.get("name"),
+                        "description": {
+                            "type": "plain_text",
+                            "text": truncate_text(task.get("name")),
+                        },
                     }
                     for task in tasks
                 ],

--- a/frappe_slack_connector/db/timesheet.py
+++ b/frappe_slack_connector/db/timesheet.py
@@ -4,7 +4,8 @@ from frappe.utils import datetime, getdate
 from frappe_slack_connector.db.employee import get_employee_from_user
 
 
-def get_user_projects(user: str, limit: int | None = 90) -> list:
+# NOTE: Slack supports a maximum of 100 options in a select menu
+def get_user_projects(user: str, limit: int | None = 99) -> list:
     """
     Get the projects for the given user
     """
@@ -22,7 +23,7 @@ def get_user_projects(user: str, limit: int | None = 90) -> list:
 def get_user_tasks(
     user: str,
     project: str | None = None,
-    limit: int = 90,
+    limit: int = 99,
 ) -> list:
     """
     Get the tasks for the given user

--- a/frappe_slack_connector/slack/interactions/timesheet_filters.py
+++ b/frappe_slack_connector/slack/interactions/timesheet_filters.py
@@ -145,9 +145,12 @@ def handle_task_select(slack: SlackIntegration, payload: dict):
 
     task = state["task_block"]["task_select"]["selected_option"]["value"]
     project = frappe.get_value("Task", task, "project")
-    project_id, project_name = frappe.get_value(
-        "Project", project, ["name", "project_name"]
-    )
+    project_fields = frappe.get_value("Project", project, ["name", "project_name"])
+
+    if project_fields is None:
+        raise Exception("Project not found for the task")
+
+    project_id, project_name = project_fields
 
     # Set the initial project option in the project block
     for block in blocks:


### PR DESCRIPTION
## Issue
If the project is deleted or not found for selected task, it is giving error:
```
cannot unpack non-iterable NoneType object
```
since the code is trying to get the fields for the project that is being returned None.

## Solution
1. This PR adds a check if the ORM call returns None, it shows a user friendly message saying the project doesn't exist.
2. Adds the Task Name (TASK-0001) to the description
3. Raise the tasks and project limit to 99 (maximum permissible by Slack is 100)