### PR TITLE
fix: typo related to translation

### DIFF
--- a/frappe_slack_connector/api/sync_slack_settings.py
+++ b/frappe_slack_connector/api/sync_slack_settings.py
@@ -38,7 +38,7 @@ def sync_slack_job():
             except Exception as e:
                 users_not_found.append((email, str(e)))
 
-        frappe.msgprint(_("Slack data synced successfully", realtime=True, indicator="green"))
+        frappe.msgprint(_("Slack data synced successfully"), realtime=True, indicator="green")
 
         # Check and display employees in ERPNext but not in Slack
         employees = frappe.get_all(


### PR DESCRIPTION
The translation function (`_`) had a mismatching parenthesis, that is why the call to the api was failing with `invalid arguments` error. This PR fixes the bracket placement.