### PR TITLE
Run Slack Sync weekly, Skip timesheet notification if taken leave on both halves

### DIFF
--- a/frappe_slack_connector/api/sync_slack_settings.py
+++ b/frappe_slack_connector/api/sync_slack_settings.py
@@ -13,10 +13,10 @@ def sync_slack_data():
     Enqueues the background job to sync
     """
     frappe.msgprint(_("Syncing Slack data..."))
-    frappe.enqueue(sync_slack_job, queue="long")
+    frappe.enqueue(sync_slack_job, queue="long", notify=True)
 
 
-def sync_slack_job():
+def sync_slack_job(notify: bool = False):
     """
     Background job to sync the Slack data with the User Meta
     """
@@ -38,7 +38,8 @@ def sync_slack_job():
             except Exception as e:
                 users_not_found.append((email, str(e)))
 
-        frappe.msgprint(_("Slack data synced successfully"), realtime=True, indicator="green")
+        if notify:
+            frappe.msgprint(_("Slack data synced successfully"), realtime=True, indicator="green")
 
         # Check and display employees in ERPNext but not in Slack
         employees = frappe.get_all(
@@ -53,12 +54,13 @@ def sync_slack_job():
                 unset_employees.append(employee.employee_name)
 
         if users_not_found:
-            frappe.msgprint(
-                f"Users not found in ERPNext: {', '.join(user[0] for user in users_not_found)}",
-                title="Warning",
-                indicator="orange",
-                realtime=True,
-            )
+            if notify:
+                frappe.msgprint(
+                    f"Users not found in ERPNext: {', '.join(user[0] for user in users_not_found)}",
+                    title="Warning",
+                    indicator="orange",
+                    realtime=True,
+                )
             generate_error_log(
                 title="Users not found in ERPNext",
                 message="\n".join(user[1] for user in users_not_found),
@@ -68,14 +70,14 @@ def sync_slack_job():
             generate_error_log(
                 title="Employees not found in Slack",
                 message=f"Users not found in Slack: {', '.join(unset_employees)}",
-                realtime=True,
-                msgprint=True,
+                msgprint=notify,
+                realtime=notify,
             )
 
     except Exception as e:
         generate_error_log(
             title="Error syncing Slack data",
             exception=e,
-            msgprint=True,
-            realtime=True,
+            msgprint=notify,
+            realtime=notify,
         )

--- a/frappe_slack_connector/hooks.py
+++ b/frappe_slack_connector/hooks.py
@@ -159,7 +159,9 @@ scheduler_events = {
     "hourly": [
         "frappe_slack_connector.tasks.send_daily_reminder.send_reminder",
     ],
-    # "weekly": ["frappe_slack_connector.tasks.weekly"],
+    "weekly": [
+        "frappe_slack_connector.api.sync_slack_settings.sync_slack_job",
+    ],
     # "monthly": ["frappe_slack_connector.tasks.monthly"],
 }
 

--- a/frappe_slack_connector/tasks/send_daily_reminder.py
+++ b/frappe_slack_connector/tasks/send_daily_reminder.py
@@ -66,8 +66,7 @@ def send_slack_notification(reminder_template: str, allowed_departments: list):
             "Leave Application",
             {
                 "employee": employee.name,
-                "from_date": ("<=", str(date)),
-                "to_date": (">=", str(date)),
+                "half_day_date": str(date),
                 "half_day": 1,
                 "status": (
                     "in",

--- a/frappe_slack_connector/tasks/send_daily_reminder.py
+++ b/frappe_slack_connector/tasks/send_daily_reminder.py
@@ -62,7 +62,7 @@ def send_slack_notification(reminder_template: str, allowed_departments: list):
 
         # check if the employee has taken a half-day
         # and set the daily norm accordingly
-        is_half_day = frappe.db.exists(
+        half_days = frappe.get_all(
             "Leave Application",
             {
                 "employee": employee.name,
@@ -75,7 +75,11 @@ def send_slack_notification(reminder_template: str, allowed_departments: list):
                 ),
             },
         )
-        if is_half_day:
+        # if half day is taken for both the first and second half of the day,
+        # then consider full day leave
+        if len(half_days) > 1:
+            continue
+        elif half_days:
             daily_norm = daily_norm / 2
 
         hour = get_reported_time_by_employee(employee.name, date)


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

This PR adds a new feature to sync slack data weekly, and fix an issue with timesheet notification.

> Explain the **details** for making this change. What existing problem does the pull request solve?

- Feat: Run scheduler job weekly to sync slack users (https://github.com/rtCamp/frappe-slack-connector/issues/68)
- Fix: Don't send `Please Fill in your timesheet` daily reminder if the employee had taken leaves in both halves separately (first and second halves) https://github.com/rtCamp/frappe-slack-connector/issues/69

> QA List

- [ ] Check Scheduler is run weekly to sync Slack with `User Meta` DocTypes
- [ ] Check `Please Fill your Timesheet` notification is not sent to the user if they have taken leaves separately for both halves.

> Screenshots/GIFs

N/A