### PR TITLE
Fix: Set user and add leave approve or reject log in activity

### DIFF
--- a/frappe_slack_connector/db/leave_application.py
+++ b/frappe_slack_connector/db/leave_application.py
@@ -57,6 +57,7 @@ def approve_leave(leave_id: str) -> None:
     leave_request.status = "Approved"
     leave_request.save(ignore_permissions=True)
     leave_request.submit()
+    leave_request.add_comment(comment_type="Info", text="approved via Slack")
 
 
 def reject_leave(leave_id: str) -> None:
@@ -68,3 +69,4 @@ def reject_leave(leave_id: str) -> None:
     leave_request.status = "Rejected"
     leave_request.save(ignore_permissions=True)
     leave_request.submit()
+    leave_request.add_comment(comment_type="Info", text="rejected via Slack")

--- a/frappe_slack_connector/slack/interactions/approve_leave.py
+++ b/frappe_slack_connector/slack/interactions/approve_leave.py
@@ -2,6 +2,7 @@ import frappe
 from frappe import _
 
 from frappe_slack_connector.db.leave_application import approve_leave, reject_leave
+from frappe_slack_connector.db.user_meta import get_userid_from_slackid
 from frappe_slack_connector.helpers.error import generate_error_log
 from frappe_slack_connector.helpers.str_utils import strip_html_tags
 from frappe_slack_connector.slack.app import SlackIntegration
@@ -18,6 +19,7 @@ def handler(slack: SlackIntegration, payload: dict):
         user_id = payload.get("user", {}).get("id")
         if not user_id:
             generate_error_log("User ID not found in payload", msgprint=True)
+        frappe.set_user(get_userid_from_slackid(user_id))
 
         action_id = payload["actions"][0]["action_id"]
         leave_id = payload["actions"][0]["value"]


### PR DESCRIPTION


## Description

This PR adds a log in user activity that records who approved or rejected leave applications via Slack. This enhancement improves traceability and accountability in the leave approval process.

## Relevant Technical Choices

- Updated the leave application activity timeline to display these logs.

## Testing Instructions

1. Submit a new leave application through the system.
2. As an approver, use the Slack interface to approve or reject the leave application.
3. Check the leave application's activity timeline in the system.
4. Verify that a new log entry appears, stating who approved or rejected the application via Slack.

## Additional Information:
N/A

## Screenshot/Screencast

<img width="502" alt="Screenshot 2025-02-06 at 2 24 28 AM" src="https://github.com/user-attachments/assets/73211bdb-d989-4804-886e-775bd1a26fe6" />


## Checklist

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Ref: #74 