### PR TITLE
Optionally mention user on leave based on setting

### DIFF
--- a/frappe_slack_connector/frappe_slack_connector/doctype/slack_settings/slack_settings.json
+++ b/frappe_slack_connector/frappe_slack_connector/doctype/slack_settings/slack_settings.json
@@ -14,6 +14,7 @@
   "slack_client_secret",
   "workspace_section",
   "send_attendance_updates",
+  "mention_user",
   "attendance_channel_id",
   "test_slack_channel",
   "column_break_tjcf",
@@ -170,12 +171,21 @@
    "fieldtype": "Date",
    "hidden": 1,
    "label": "Last Timesheet Notification Date"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.send_attendance_updates",
+   "description": "Enable this if you want to mention user on leave.",
+   "fieldname": "mention_user",
+   "fieldtype": "Check",
+   "label": "Mention User",
+   "mandatory_depends_on": "eval:doc.send_attendance_updates"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-11-06 22:22:21.421681",
+ "modified": "2025-05-27 18:54:28.174707",
  "modified_by": "Administrator",
  "module": "Frappe Slack Connector",
  "name": "Slack Settings",

--- a/frappe_slack_connector/override/leave_application.py
+++ b/frappe_slack_connector/override/leave_application.py
@@ -133,6 +133,7 @@ def send_leave_notification_bg(doc: Document):
 
     try:
         user_slack = slack.get_slack_user_id(employee_id=doc.employee)
+        mention_users = frappe.db.get_single_value("Slack Settings", "mention_user")
         mention = f"<@{user_slack}>" if user_slack else doc.employee_name
         day_period = "Full Day"
         if doc.half_day and doc.half_day_date == frappe.utils.today():
@@ -155,7 +156,8 @@ def send_leave_notification_bg(doc: Document):
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": f"{mention} requested for leave today. " + f"_({day_period})_",
+                            "text": f"{mention if mention_users else doc.employee_name} requested for leave today. "
+                            + f"_({day_period})_",
                         },
                     },
                 ],

--- a/frappe_slack_connector/tasks/attendance_summary.py
+++ b/frappe_slack_connector/tasks/attendance_summary.py
@@ -60,7 +60,7 @@ def send_notification(attendance_title: str) -> str | None:
     Returns the message timestamp if successful
     """
     slack = SlackIntegration()
-
+    mention_users = frappe.db.get_single_value("Slack Settings", "mention_user")
     leave_groups = {"Full Day": [], "Half Day": []}
     if custom_fields_exist():
         leave_groups["First-Half"] = []
@@ -71,7 +71,7 @@ def send_notification(attendance_title: str) -> str | None:
         user_slack = get_user_meta(employee_id=user_application.get("employee"))
         slack_name = (
             f"<@{user_slack.custom_slack_userid}>"
-            if user_slack and user_slack.custom_slack_userid
+            if user_slack and user_slack.custom_slack_userid and mention_users
             else user_application.employee_name
         )
 


### PR DESCRIPTION
This pull request introduces a new feature to the Frappe Slack Connector, enabling the option to mention users in Slack notifications for leave applications and attendance summaries. The changes primarily focus on adding a new field in the `Slack Settings` doctype and updating notification logic to incorporate this feature.