### PR TITLE
Refactor: Use workflow to trigger approval/rejection in case of rtCamp

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -23,7 +23,7 @@ jobs:
       - name: fix tar dependency in alpine container image
         run: |
           apk --no-cache add tar nodejs npm python3 git bash py3-pip
-          apk --no-cache add prettier --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing
+          npm install -g prettier
           # check python modules installed versions
           python3 -m pip freeze --local
           pip install pre-commit --break-system-packages

--- a/frappe_slack_connector/db/leave_application.py
+++ b/frappe_slack_connector/db/leave_application.py
@@ -55,9 +55,12 @@ def approve_leave(leave_id: str) -> None:
     """
     # Logic to approve the leave request
     leave_request = frappe.get_doc("Leave Application", leave_id)
-    leave_request.status = "Approved"
-    leave_request.save(ignore_permissions=True)
-    leave_request.submit()
+    if custom_fields_exist():
+        apply_workflow(leave_request, "Approve")
+    else:
+        leave_request.status = "Approved"
+        leave_request.save(ignore_permissions=True)
+        leave_request.submit()
     leave_request.add_comment(comment_type="Info", text="approved via Slack")
 
 
@@ -67,9 +70,10 @@ def reject_leave(leave_id: str) -> None:
     """
     # Logic to reject the leave request
     leave_request = frappe.get_doc("Leave Application", leave_id)
-    leave_request.status = "Rejected"
-    leave_request.save(ignore_permissions=True)
     if custom_fields_exist():
         apply_workflow(leave_request, "Reject")
-    leave_request.submit()
+    else:
+        leave_request.status = "Rejected"
+        leave_request.save(ignore_permissions=True)
+        leave_request.submit()
     leave_request.add_comment(comment_type="Info", text="rejected via Slack")

--- a/frappe_slack_connector/db/leave_application.py
+++ b/frappe_slack_connector/db/leave_application.py
@@ -68,5 +68,7 @@ def reject_leave(leave_id: str) -> None:
     leave_request = frappe.get_doc("Leave Application", leave_id)
     leave_request.status = "Rejected"
     leave_request.save(ignore_permissions=True)
+    if custom_fields_exist():
+        leave_request.workflow_state = "Rejected"
     leave_request.submit()
     leave_request.add_comment(comment_type="Info", text="rejected via Slack")

--- a/frappe_slack_connector/db/leave_application.py
+++ b/frappe_slack_connector/db/leave_application.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe.model.workflow import apply_workflow
 from frappe.utils import today
 
 
@@ -69,6 +70,6 @@ def reject_leave(leave_id: str) -> None:
     leave_request.status = "Rejected"
     leave_request.save(ignore_permissions=True)
     if custom_fields_exist():
-        leave_request.workflow_state = "Rejected"
+        apply_workflow(leave_request, "Reject")
     leave_request.submit()
     leave_request.add_comment(comment_type="Info", text="rejected via Slack")

--- a/frappe_slack_connector/db/leave_application.py
+++ b/frappe_slack_connector/db/leave_application.py
@@ -59,7 +59,7 @@ def approve_leave(leave_id: str) -> None:
         apply_workflow(leave_request, "Approve")
     else:
         leave_request.status = "Approved"
-        leave_request.save(ignore_permissions=True)
+        leave_request.save()
         leave_request.submit()
     leave_request.add_comment(comment_type="Info", text="approved via Slack")
 
@@ -74,6 +74,6 @@ def reject_leave(leave_id: str) -> None:
         apply_workflow(leave_request, "Reject")
     else:
         leave_request.status = "Rejected"
-        leave_request.save(ignore_permissions=True)
+        leave_request.save()
         leave_request.submit()
     leave_request.add_comment(comment_type="Info", text="rejected via Slack")


### PR DESCRIPTION
## Description

This PR updates the Leave Application workflow handling:
- Sets the workflow_state to Rejected when a leave application is rejected.
- Uses the recommended apply_workflow API to transition workflow states, ensuring consistency with Frappe’s workflow engine.
- Adds a conditional check to trigger the workflow only if the required custom fields exist on the document.

## Relevant Technical Choices
- Replaced manual state updates with frappe.workflow.apply_workflow, ensuring permissions and transitions are validated correctly.
- Introduced a conditional block to only apply workflow changes if the relevant custom fields are present, avoiding unnecessary actions on other doctypes or incomplete setups.

## Testing Instructions



1.	Create a Leave Application.
2.	Ensure the required custom fields (if any) exist on the document.
3.	Trigger a rejection (using the UI or API) and verify:
	•	The workflow state updates to “Rejected.”
	•	The appropriate workflow transition is applied.
4.	Remove the custom fields and try the same action—verify that no workflow is triggered and no errors are thrown.
5.	Approve a leave application and verify that the workflow works as expected.

## Additional Information:
N/A

## Screenshot/Screencast

N/A

## Checklist
- [x]	I have carefully reviewed the code before submitting it for review.
- [ ]	This code is adequately covered by unit tests to validate its functionality.
- [x]	I have conducted thorough testing to ensure it functions as intended.
- [ ]	A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)


Fix #87 

