### PR TITLE
Refactor: Use workflow to trigger approval/rejection in case of rtCamp

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -45,7 +45,13 @@ jobs:
       - name: Get APP and Build
         run: |
           cd /home/frappe/frappe-bench
-          su frappe bash -c "bench get-app https://rtbot:${{ secrets.RTBOT_TOKEN }}@github.com/${{ github.repository }} --branch ${{ github.head_ref || github.ref_name }}"
+          if [ "${{ github.event.pull_request.head.repo.private }}" = "false" ]; then
+            # Public fork
+            su frappe bash -c "bench get-app https://github.com/${{ github.event.pull_request.head.repo.full_name }} --branch ${{ github.event.pull_request.head.ref }}"
+          else
+            # Private fork (requires token)
+            su frappe bash -c "bench get-app https://rtbot:${{ secrets.RTBOT_TOKEN }}@github.com/${{ github.event.pull_request.head.repo.full_name }} --branch ${{ github.event.pull_request.head.ref }}"
+          fi
 
       - name: Cleanup
         if: ${{ always() }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -25,6 +25,23 @@ jobs:
           cd /home/frappe
           su frappe bash -c "bench init frappe-bench --skip-redis-config-generation --no-procfile --skip-assets"
 
+      - name: Get Dependent Apps
+        run: |
+          cd /home/frappe/frappe-bench
+          # Use public URL for public repos, authenticated URL for private repos
+          if [ "${{ github.event.pull_request.head.repo.private }}" = "false" ]; then
+            # This is a public repository (could be a fork or not)
+            git clone https://github.com/${{ github.event.pull_request.head.repo.full_name }} -b ${{ github.event.pull_request.head.ref }} --depth=1 app_repo
+          else
+            # Private repository, use authentication
+            git clone https://rtbot:${{ secrets.RTBOT_TOKEN }}@github.com/${{ github.event.pull_request.head.repo.full_name }} -b ${{ github.event.pull_request.head.ref }} --depth=1 app_repo
+          fi
+          DEPS=$(grep -E "required_apps\s*=\s*\[" app_repo/*/hooks.py | sed 's/.*\[\(.*\)\]/\1/g' | tr -d '"' | tr -d "'" | tr ',' '\n' | awk '{$1=$1};1')
+          rm -rf app_repo
+          for dep in $DEPS; do
+            su frappe bash -c "bench get-app $dep"
+          done
+
       - name: Get APP and Build
         run: |
           cd /home/frappe/frappe-bench


### PR DESCRIPTION
## Description

This PR updates the Leave Application workflow handling:
- Sets the workflow_state to Rejected when a leave application is rejected.
- Uses the recommended apply_workflow API to transition workflow states, ensuring consistency with Frappe’s workflow engine.
- Adds a conditional check to trigger the workflow only if the required custom fields exist on the document.

## Relevant Technical Choices
- Replaced manual state updates with frappe.workflow.apply_workflow, ensuring permissions and transitions are validated correctly.
- Introduced a conditional block to only apply workflow changes if the relevant custom fields are present, avoiding unnecessary actions on other doctypes or incomplete setups.

## Testing Instructions



1.	Create a Leave Application.
2.	Ensure the required custom fields (if any) exist on the document.
3.	Trigger a rejection (using the UI or API) and verify:
	•	The workflow state updates to “Rejected.”
	•	The appropriate workflow transition is applied.
4.	Remove the custom fields and try the same action—verify that no workflow is triggered and no errors are thrown.
5.	Approve a leave application and verify that the workflow works as expected.

## Additional Information:
N/A

## Screenshot/Screencast

N/A

## Checklist
- [x]	I have carefully reviewed the code before submitting it for review.
- [ ]	This code is adequately covered by unit tests to validate its functionality.
- [x]	I have conducted thorough testing to ensure it functions as intended.
- [ ]	A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)


Fix #87 

