### PR TITLE
fix(db): exclude inactive employees from get_employees_on_leave query

### DIFF
--- a/frappe_slack_connector/db/leave_application.py
+++ b/frappe_slack_connector/db/leave_application.py
@@ -31,7 +31,18 @@ def get_employees_on_leave() -> list:
     if custom_fields_exist():
         fields.append("custom_first_halfsecond_half")
 
-    # Query Leave Application doctype
+    # 1. Fetch only Active employees
+    active_employees = frappe.get_all(
+        "Employee",
+        filters={"status": "Active"},
+        pluck="name"
+    )
+
+    # Performance safeguard: If no active employees exist, skip the main query
+    if not active_employees:
+        return []
+
+    # 2. Query Leave Application doctype, filtering by the active employees list
     leave_applications = frappe.get_all(
         "Leave Application",
         filters={
@@ -41,6 +52,7 @@ def get_employees_on_leave() -> list:
                 "in",
                 ["Open", "Approved"],
             ),
+            "employee": ("in", active_employees), # <-- NEW FILTER ADDED HERE
         },
         fields=fields,
         order_by="to_date asc",


### PR DESCRIPTION
## Description
Exclude inactive employees from the daily leave notification list.

## Relevant Technical Choices

I modified get_employees_on_leave() to perform a two-step verification:

1.First, it fetches all employee names where status is 'Active'.
2.It then filters the Leave Application results to only include those belonging to the active employee list.
This prevents the system from sending Slack notifications for approved leaves belonging to former employees.

## Testing Instructions

1.Create two employees: "Active Alice" (Status: Active) and "Inactive Ian" (Status: Left).
2.Create and Submit an approved Leave Application for both for today’s date.
3.Run bench console.
4.Import and run get_employees_on_leave().
5.Expected Result: Only "Active Alice" is returned; "Inactive Ian" is excluded.

## Additional Information:

Reproduced the edge-case where a leave is approved while an employee is active, but the employee departs before the leave date occurs.

## Screenshot/Screencast
<img width="1739" height="1157" alt="2961d18a-79b0-4823-9189-7438ead52632" src="https://github.com/user-attachments/assets/5c370f21-e0c5-4e83-a979-770694a5f45c" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [X] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [X] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #93 