### PR TITLE
feat: add Slack Channel sync for automated PM report

### DIFF
--- a/frappe_slack_connector/api/sync_slack_settings.py
+++ b/frappe_slack_connector/api/sync_slack_settings.py
@@ -81,3 +81,66 @@ def sync_slack_job(notify: bool = False):
             msgprint=notify,
             realtime=notify,
         )
+
+
+@frappe.whitelist()
+def sync_slack_channels():
+    """
+    Sync Slack channels into Slack Channel doctype
+    """
+    frappe.msgprint(_("Syncing Slack channels..."))
+    frappe.enqueue(sync_slack_channels_job, queue="long", notify=True)
+
+
+def sync_slack_channels_job(notify: bool = False):
+    """
+    Background job to sync Slack channels into Slack Channel doctype
+    """
+    try:
+        slack = SlackIntegration()
+        channels = slack.get_slack_channels()
+
+        if not channels:
+            return
+
+        # Fetch all existing channels in ONE query
+        existing = frappe.db.get_all(
+            "Slack Channel",
+            fields=["name", "channel_id", "channel_name"],
+        )
+        existing_map = {
+            ch["channel_name"]: {"name": ch["name"], "channel_id": ch["channel_id"], "channel_name": ch["channel_name"]}
+            for ch in existing
+        }
+
+        for ch in channels:
+            if ch["name"] in existing_map:
+                # Only update if something changed
+                if existing_map[ch["name"]]["channel_name"] != ch["name"]:
+                    frappe.db.set_value("Slack Channel", existing_map[ch["name"]]["name"], "channel_name", ch["name"])
+                # else skip — nothing changed
+            else:
+                frappe.get_doc(
+                    {
+                        "doctype": "Slack Channel",
+                        "channel_id": ch["id"],
+                        "channel_name": ch["name"],
+                    }
+                ).insert(ignore_permissions=True)
+
+        frappe.db.commit()
+
+        if notify:
+            frappe.msgprint(
+                _("Synced {0} Slack channels successfully").format(len(channels)),
+                realtime=True,
+                indicator="green",
+            )
+
+    except Exception as e:
+        generate_error_log(
+            title="Error syncing Slack channels",
+            exception=e,
+            msgprint=notify,
+            realtime=notify,
+        )

--- a/frappe_slack_connector/frappe_slack_connector/doctype/slack_channel/slack_channel.js
+++ b/frappe_slack_connector/frappe_slack_connector/doctype/slack_channel/slack_channel.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2026, rtCamp and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Slack Channel", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/frappe_slack_connector/frappe_slack_connector/doctype/slack_channel/slack_channel.json
+++ b/frappe_slack_connector/frappe_slack_connector/doctype/slack_channel/slack_channel.json
@@ -1,0 +1,104 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:channel_name",
+ "creation": "2026-04-28 16:10:00.025687",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "channel_id",
+  "channel_name"
+ ],
+ "fields": [
+  {
+   "fieldname": "channel_id",
+   "fieldtype": "Data",
+   "label": "Channel ID",
+   "unique": 1
+  },
+  {
+   "fieldname": "channel_name",
+   "fieldtype": "Data",
+   "label": "Channel Name",
+   "unique": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-04-30 16:45:42.233029",
+ "modified_by": "Administrator",
+ "module": "Frappe Slack Connector",
+ "name": "Slack Channel",
+ "naming_rule": "By fieldname",
+ "owner": "manya@gmail.com",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Projects User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Hiring Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Agent Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Leave Approver",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "show_title_field_in_link": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "channel_name"
+}

--- a/frappe_slack_connector/frappe_slack_connector/doctype/slack_channel/slack_channel.py
+++ b/frappe_slack_connector/frappe_slack_connector/doctype/slack_channel/slack_channel.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, rtCamp and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class SlackChannel(Document):
+    pass

--- a/frappe_slack_connector/frappe_slack_connector/doctype/slack_channel/test_slack_channel.py
+++ b/frappe_slack_connector/frappe_slack_connector/doctype/slack_channel/test_slack_channel.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, rtCamp and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestSlackChannel(FrappeTestCase):
+    pass

--- a/frappe_slack_connector/hooks.py
+++ b/frappe_slack_connector/hooks.py
@@ -170,6 +170,7 @@ scheduler_events = {
     "weekly": [
         "frappe_slack_connector.api.sync_slack_settings.sync_slack_job",
     ],
+    "daily": ["frappe_slack_connector.api.sync_slack_settings.sync_slack_channels_job"],
     # "monthly": ["frappe_slack_connector.tasks.monthly"],
 }
 

--- a/frappe_slack_connector/slack/app.py
+++ b/frappe_slack_connector/slack/app.py
@@ -192,3 +192,34 @@ class SlackIntegration:
         """
         slack_user = self.get_slack_user(*args, **kwargs)
         return slack_user.get("id") if slack_user else None
+
+    def get_slack_channels(self, limit: int = 200) -> list[dict]:
+        """
+        Get all active Slack channels from the workspace
+        Uses pagination to handle large numbers of channels
+        """
+        channels = []
+        cursor = None
+
+        while True:
+            try:
+                kwargs = {"types": "public_channel,private_channel", "exclude_archived": True, "limit": limit}
+                if cursor:
+                    kwargs["cursor"] = cursor
+
+                result = self.slack_app.client.conversations_list(**kwargs)
+
+                channels.extend([{"id": ch["id"], "name": ch["name"]} for ch in result.get("channels", [])])
+
+                cursor = result.get("response_metadata", {}).get("next_cursor")
+                if not cursor:
+                    break
+
+            except Exception as e:
+                generate_error_log(
+                    title="Error fetching Slack channels",
+                    exception=e,
+                )
+                break
+
+        return channels


### PR DESCRIPTION
## Description

Adds Slack channel sync functionality that fetches all active channels from the connected Slack workspace and stores them in the Slack Channel doctype. Sync runs daily via scheduler and can also be triggered manually.

## Relevant Technical Choices

- Added get_slack_channels() in app.py with cursor-based pagination to handle large workspaces.
- Single DB query to fetch all existing channels before sync to avoid N+1 queries.
- Skip-if-unchanged logic to avoid unnecessary DB writes.
- Archived channels are excluded via exclude_archived=True.
- Sync runs as a background job on the long queue with real-time user feedback.
- Registered under scheduler_events["daily"] in hooks.py.

## Testing Instructions

1. Ensure the Slack bot token has channels:read and groups:read scopes.
2. Trigger the sync manually via the sync_slack_channels_job whitelisted endpoint.
3. Verify Slack Channel records are created matching your Slack workspace.
4. Re-run and confirm no duplicates are created.

## Additional Information:

Required for PM Reporting in [Next PMS](https://github.com/rtCamp/next-pms/pull/1285)

## Screenshot/Screencast

<img width="1107" height="587" alt="image" src="https://github.com/user-attachments/assets/ea2b2a62-9af8-4457-a094-e5713246c0ef" />

<img width="2904" height="1534" alt="image" src="https://github.com/user-attachments/assets/aac63113-4e93-4c6b-9065-75efccd86d6c" />




## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes 

- [AI Internal Issue](https://github.com/rtCamp/AI-Internal/issues/9)