### PR TITLE
Add Slack Channel sync and fix PMS System link

### DIFF
--- a/frappe_slack_connector/api/sync_slack_settings.py
+++ b/frappe_slack_connector/api/sync_slack_settings.py
@@ -81,3 +81,66 @@ def sync_slack_job(notify: bool = False):
             msgprint=notify,
             realtime=notify,
         )
+
+
+@frappe.whitelist()
+def sync_slack_channels():
+    """
+    Sync Slack channels into Slack Channel doctype
+    """
+    frappe.msgprint(_("Syncing Slack channels..."))
+    frappe.enqueue(sync_slack_channels_job, queue="long", notify=True)
+
+
+def sync_slack_channels_job(notify: bool = False):
+    """
+    Background job to sync Slack channels into Slack Channel doctype
+    """
+    try:
+        slack = SlackIntegration()
+        channels = slack.get_slack_channels()
+
+        if not channels:
+            return
+
+        # Fetch all existing channels in ONE query
+        existing = frappe.db.get_all(
+            "Slack Channel",
+            fields=["name", "channel_id", "channel_name"],
+        )
+        existing_map = {
+            ch["channel_name"]: {"name": ch["name"], "channel_id": ch["channel_id"], "channel_name": ch["channel_name"]}
+            for ch in existing
+        }
+
+        for ch in channels:
+            if ch["name"] in existing_map:
+                # Only update if something changed
+                if existing_map[ch["name"]]["channel_name"] != ch["name"]:
+                    frappe.db.set_value("Slack Channel", existing_map[ch["name"]]["name"], "channel_name", ch["name"])
+                # else skip — nothing changed
+            else:
+                frappe.get_doc(
+                    {
+                        "doctype": "Slack Channel",
+                        "channel_id": ch["id"],
+                        "channel_name": ch["name"],
+                    }
+                ).insert(ignore_permissions=True)
+
+        frappe.db.commit()
+
+        if notify:
+            frappe.msgprint(
+                _("Synced {0} Slack channels successfully").format(len(channels)),
+                realtime=True,
+                indicator="green",
+            )
+
+    except Exception as e:
+        generate_error_log(
+            title="Error syncing Slack channels",
+            exception=e,
+            msgprint=notify,
+            realtime=notify,
+        )

--- a/frappe_slack_connector/frappe_slack_connector/doctype/slack_channel/slack_channel.js
+++ b/frappe_slack_connector/frappe_slack_connector/doctype/slack_channel/slack_channel.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2026, rtCamp and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Slack Channel", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/frappe_slack_connector/frappe_slack_connector/doctype/slack_channel/slack_channel.json
+++ b/frappe_slack_connector/frappe_slack_connector/doctype/slack_channel/slack_channel.json
@@ -1,0 +1,104 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:channel_name",
+ "creation": "2026-04-28 16:10:00.025687",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "channel_id",
+  "channel_name"
+ ],
+ "fields": [
+  {
+   "fieldname": "channel_id",
+   "fieldtype": "Data",
+   "label": "Channel ID",
+   "unique": 1
+  },
+  {
+   "fieldname": "channel_name",
+   "fieldtype": "Data",
+   "label": "Channel Name",
+   "unique": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-04-30 16:45:42.233029",
+ "modified_by": "Administrator",
+ "module": "Frappe Slack Connector",
+ "name": "Slack Channel",
+ "naming_rule": "By fieldname",
+ "owner": "manya@gmail.com",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Projects User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Hiring Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Agent Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Leave Approver",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "show_title_field_in_link": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "channel_name"
+}

--- a/frappe_slack_connector/frappe_slack_connector/doctype/slack_channel/slack_channel.py
+++ b/frappe_slack_connector/frappe_slack_connector/doctype/slack_channel/slack_channel.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, rtCamp and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class SlackChannel(Document):
+    pass

--- a/frappe_slack_connector/frappe_slack_connector/doctype/slack_channel/test_slack_channel.py
+++ b/frappe_slack_connector/frappe_slack_connector/doctype/slack_channel/test_slack_channel.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, rtCamp and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestSlackChannel(FrappeTestCase):
+    pass

--- a/frappe_slack_connector/hooks.py
+++ b/frappe_slack_connector/hooks.py
@@ -170,6 +170,7 @@ scheduler_events = {
     "weekly": [
         "frappe_slack_connector.api.sync_slack_settings.sync_slack_job",
     ],
+    "daily": ["frappe_slack_connector.api.sync_slack_settings.sync_slack_channels_job"],
     # "monthly": ["frappe_slack_connector.tasks.monthly"],
 }
 

--- a/frappe_slack_connector/slack/app.py
+++ b/frappe_slack_connector/slack/app.py
@@ -192,3 +192,34 @@ class SlackIntegration:
         """
         slack_user = self.get_slack_user(*args, **kwargs)
         return slack_user.get("id") if slack_user else None
+
+    def get_slack_channels(self, limit: int = 200) -> list[dict]:
+        """
+        Get all active Slack channels from the workspace
+        Uses pagination to handle large numbers of channels
+        """
+        channels = []
+        cursor = None
+
+        while True:
+            try:
+                kwargs = {"types": "public_channel,private_channel", "exclude_archived": True, "limit": limit}
+                if cursor:
+                    kwargs["cursor"] = cursor
+
+                result = self.slack_app.client.conversations_list(**kwargs)
+
+                channels.extend([{"id": ch["id"], "name": ch["name"]} for ch in result.get("channels", [])])
+
+                cursor = result.get("response_metadata", {}).get("next_cursor")
+                if not cursor:
+                    break
+
+            except Exception as e:
+                generate_error_log(
+                    title="Error fetching Slack channels",
+                    exception=e,
+                )
+                break
+
+        return channels

--- a/frappe_slack_connector/tasks/workload_reminder.py
+++ b/frappe_slack_connector/tasks/workload_reminder.py
@@ -286,7 +286,7 @@ def format_daily_workload_blocks(employee_count: int, section_texts: list) -> li
             "elements": [
                 {
                     "type": "mrkdwn",
-                    "text": f":bulb: _Please ensure all allocations are updated in the PMS system._ <{link}|link>",
+                    "text": f":bulb: _Please ensure all allocations are updated in the <{link}|PMS system>._",
                 }
             ],
         }


### PR DESCRIPTION
## Description

This pull request introduces a new "Slack Channel" DocType to the Frappe Slack Connector app, enabling the system to sync Slack channels from a workspace into ERPNext. The changes include the creation of the new DocType, backend logic to fetch and store Slack channels, background job scheduling, and supporting code for integration and testing.

**Slack Channel DocType and Backend Integration:**

* Added a new DocType called `Slack Channel` with fields for `channel_id` and `channel_name`, including permissions for relevant user roles.
* Implemented the `SlackChannel` Python class to represent the new DocType.
* Created a backend API method `sync_slack_channels` and a background job `sync_slack_channels_job` to fetch channels from Slack and upsert them into the `Slack Channel` DocType, with error handling and user notifications.
* Added a method `get_slack_channels` to the Slack integration logic to retrieve all active Slack channels from the workspace using Slack API pagination.

**Scheduling and Testing:**

* Registered the new sync job to run daily using ERPNext's scheduler.
* Added a test skeleton for the `Slack Channel` DocType.

**Other Minor Changes:**

* Updated the workload reminder message to clarify the PMS system link formatting.
* Added a placeholder client-side script for the new DocType.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:


## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #