### PR TITLE
fix: pass signing_secret to slack_bolt App constructor

### DIFF
--- a/frappe_slack_connector/slack/app.py
+++ b/frappe_slack_connector/slack/app.py
@@ -34,7 +34,10 @@ class SlackIntegration:
                 title="Slack Config not set in the Slack Settings",
                 msgprint=True,
             )
-        self.slack_app = App(token=self.SLACK_BOT_TOKEN)
+        self.slack_app = App(
+            token=self.SLACK_BOT_TOKEN,
+            signing_secret=self.SLACK_SIGNATURE,
+        )
 
     def __check_slack_config(self) -> bool:
         """


### PR DESCRIPTION
## Description
Prevent `ValueError: signing_secret must not be empty.` from crashing the Slack Integration on initialization. This crash occurs in environments running `slack_sdk>=3.43.0` due to new eager validation on the `signing_secret` property.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

[[slackapi/python-slack-sdk Pull Request #1884]](https://github.com/slackapi/python-slack-sdk/pull/1884)

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #